### PR TITLE
Allow node names to contains a dash

### DIFF
--- a/munin2/static/dynatempl3.js
+++ b/munin2/static/dynatempl3.js
@@ -1,4 +1,3 @@
-
 /*** Graphs Zoom in/out ***/
 function ZoomIN(elem) {
 	// get the original image size
@@ -45,7 +44,7 @@ function SwitchPeriod(period) {
 	var src;
 	$(".maincategory img").each( function (i, val) {
 		src = $(this).attr("src");
-		src = src.replace(/-.*$/, "-"+period+".png");
+		src = src.replace(/.*\/[a-zA-Z0-9_]-\..*$/, "-"+period+".png");
 		$(this).attr("src", src);
 	});
 	setCookie("period", period)


### PR DESCRIPTION
With the old regexp, an image URL like that
`http://domain.com/munin/domain.com/dashed-server-name.domain.com/image-day.png`
would be transform into
`http://domain.com/munin/domain.com/dashed-day.png`

I think that the regexp might be enhanced again but it's a start :)
